### PR TITLE
[Testnet] Multisig Contract

### DIFF
--- a/Testnet/Multisig/Multisig.Tests/BaseContractTest.cs
+++ b/Testnet/Multisig/Multisig.Tests/BaseContractTest.cs
@@ -1,0 +1,72 @@
+using System;
+using Moq;
+using Stratis.SmartContracts;
+using Stratis.SmartContracts.CLR;
+using Stratis.SmartContracts.CLR.Serialization;
+
+namespace Multisig.Tests
+{
+    public class BaseContractTest
+    {
+        private readonly Mock<ISmartContractState> MockContractState;
+        private readonly Mock<IContractLogger> MockContractLogger;
+        private readonly Mock<IInternalTransactionExecutor> MockInternalExecutor;
+        private readonly InMemoryState PersistentState;
+        protected readonly ISerializer Serializer;
+        protected readonly Address Contract;
+        protected readonly Address Owner;
+        protected readonly Address AddressOne;
+        protected readonly Address AddressTwo;
+        protected readonly Address AddressThree;
+        protected readonly Address AddressFour;
+        protected readonly Address AddressFive;
+        protected readonly Address AddressSix;
+
+        protected BaseContractTest()
+        {
+            Serializer = new Serializer(new ContractPrimitiveSerializerV2(null)); // new SmartContractsPoARegTest()
+            PersistentState = new InMemoryState();
+            MockContractLogger = new Mock<IContractLogger>();
+            MockContractState = new Mock<ISmartContractState>();
+            MockInternalExecutor = new Mock<IInternalTransactionExecutor>();
+            MockContractState.Setup(x => x.PersistentState).Returns(PersistentState);
+            MockContractState.Setup(x => x.ContractLogger).Returns(MockContractLogger.Object);
+            MockContractState.Setup(x => x.InternalTransactionExecutor).Returns(MockInternalExecutor.Object);
+            MockContractState.Setup(x => x.Serializer).Returns(Serializer);
+            Contract = "0x0000000000000000000000000000000000000001".HexToAddress();
+            Owner = "0x0000000000000000000000000000000000000002".HexToAddress();
+            AddressOne = "0x0000000000000000000000000000000000000003".HexToAddress();
+            AddressTwo = "0x0000000000000000000000000000000000000004".HexToAddress();
+            AddressThree = "0x0000000000000000000000000000000000000005".HexToAddress();
+            AddressFour = "0x0000000000000000000000000000000000000006".HexToAddress();
+            AddressFive = "0x0000000000000000000000000000000000000007".HexToAddress();
+            AddressSix = "0x0000000000000000000000000000000000000008".HexToAddress();
+        }
+
+        protected MultisigContract CreateNewMultisigContract()
+        {
+            MockContractState.Setup(x => x.Message).Returns(new Message(Contract, Owner, 0));
+
+            var addresses = new[] {AddressOne, AddressTwo, AddressThree};
+            var bytes = Serializer.Serialize(addresses);
+            uint required = 2;
+
+            return new MultisigContract(MockContractState.Object, bytes, required);
+        }
+
+        protected void SetupMessage(Address contractAddress, Address sender, ulong value = 0)
+        {
+            MockContractState.Setup(x => x.Message).Returns(new Message(contractAddress, sender, value));
+        }
+
+        protected void SetupBlock(ulong blockNumber)
+        {
+            MockContractState.Setup(x => x.Block.Number).Returns(blockNumber);
+        }
+
+        protected void VerifyLog<T>(T expectedLog, Func<Times> times) where T : struct
+        {
+            MockContractLogger.Verify(x => x.Log(MockContractState.Object, expectedLog), times);
+        }
+    }
+}

--- a/Testnet/Multisig/Multisig.Tests/InMemoryState.cs
+++ b/Testnet/Multisig/Multisig.Tests/InMemoryState.cs
@@ -1,0 +1,76 @@
+using NBitcoin;
+using Stratis.SmartContracts;
+using System;
+using System.Collections.Generic;
+
+namespace Multisig.Tests
+{
+    public class InMemoryState : IPersistentState
+    {
+        private readonly Dictionary<string, object> _storage = new Dictionary<string, object>();
+
+        public bool IsContractResult { get; set; }
+
+        public void Clear(string key) => _storage.Remove(key);
+
+        public T GetValue<T>(string key) => (T)_storage.GetValueOrDefault(key, default(T));
+
+        public Address GetAddress(string key) => GetValue<Address>(key);
+
+        public T[] GetArray<T>(string key) => GetValue<T[]>(key);
+
+        public bool GetBool(string key) => GetValue<bool>(key);
+
+        public byte[] GetBytes(byte[] key) => throw new NotImplementedException();
+
+        public byte[] GetBytes(string key) => GetValue<byte[]>(key);
+
+        public char GetChar(string key) => GetValue<char>(key);
+
+        public int GetInt32(string key) => GetValue<int>(key);
+
+        public long GetInt64(string key) => GetValue<long>(key);
+
+        public UInt256 GetUInt256(string key) => GetValue<UInt256>(key);
+
+        public string GetString(string key) => GetValue<string>(key);
+
+        public T GetStruct<T>(string key) where T : struct => GetValue<T>(key);
+
+        public uint GetUInt32(string key) => GetValue<uint>(key);
+
+        public ulong GetUInt64(string key) => GetValue<ulong>(key);
+
+        public UInt128 GetUInt128(string key) => GetValue<UInt128>(key);
+
+        public bool IsContract(Address address) => IsContractResult;
+
+        public void SetAddress(string key, Address value) => _storage.AddOrReplace(key, value);
+
+        public void SetArray(string key, Array a) => _storage.AddOrReplace(key, a);
+
+        public void SetBool(string key, bool value) => _storage.AddOrReplace(key, value);
+
+        public void SetBytes(byte[] key, byte[] value) => throw new NotImplementedException();
+
+        public void SetBytes(string key, byte[] value) => _storage.AddOrReplace(key, value);
+
+        public void SetChar(string key, char value) => _storage.AddOrReplace(key, value);
+
+        public void SetInt32(string key, int value) => _storage.AddOrReplace(key, value);
+
+        public void SetInt64(string key, long value) => _storage.AddOrReplace(key, value);
+
+        public void SetUInt256(string key, UInt256 value) => _storage.AddOrReplace(key, value);
+
+        public void SetString(string key, string value) => _storage.AddOrReplace(key, value);
+
+        public void SetStruct<T>(string key, T value) where T : struct => _storage.AddOrReplace(key, value);
+
+        public void SetUInt32(string key, uint value) => _storage.AddOrReplace(key, value);
+
+        public void SetUInt64(string key, ulong value) => _storage.AddOrReplace(key, value);
+
+        public void SetUInt128(string key, UInt128 value) => _storage.AddOrReplace(key, value);
+    }
+}

--- a/Testnet/Multisig/Multisig.Tests/Multisig.Tests.csproj
+++ b/Testnet/Multisig/Multisig.Tests/Multisig.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <RootNamespace>Multisig.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Stratis.Sidechains.Networks" Version="1.1.1" />
+        <PackageReference Include="Stratis.SmartContracts" Version="2.0.0" />
+        <PackageReference Include="Stratis.SmartContracts.CLR" Version="2.0.2" />
+        <PackageReference Include="Stratis.SmartContracts.Core" Version="2.0.3" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Multisig\Multisig.csproj" />
+    </ItemGroup>
+</Project>

--- a/Testnet/Multisig/Multisig.Tests/MultisigTests.cs
+++ b/Testnet/Multisig/Multisig.Tests/MultisigTests.cs
@@ -263,6 +263,36 @@ namespace Multisig.Tests
         }
 
         [Fact]
+        public void Confirmations_ForSubmittedTransaction_ReturnsOne()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            // Note: submission is an implicit confirmation by the submitter
+
+            multiSigContract.Confirmations(transactionId).Should().Be(1);
+        }
+
+        [Fact]
+        public void Confirmations_AfterConfirmingTransaction_Increases()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            SetupMessage(Contract, AddressTwo);
+
+            multiSigContract.Confirm(transactionId);
+
+            multiSigContract.Confirmations(transactionId).Should().Be(2);
+        }
+
+        [Fact]
         public void IsConfirmedBy_ForSubmittedTransaction_ReturnsTrue()
         {
             var multiSigContract = CreateNewMultisigContract();

--- a/Testnet/Multisig/Multisig.Tests/MultisigTests.cs
+++ b/Testnet/Multisig/Multisig.Tests/MultisigTests.cs
@@ -1,0 +1,399 @@
+using FluentAssertions;
+using Stratis.SmartContracts;
+using Xunit;
+
+namespace Multisig.Tests
+{
+    public class MultisigTests : BaseContractTest
+    {
+        [Fact]
+        public void CreatesMultisigContract_Success()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressOne).Should().BeTrue();
+            multiSigContract.IsOwner(AddressTwo).Should().BeTrue();
+            multiSigContract.IsOwner(AddressThree).Should().BeTrue();
+
+            multiSigContract.OwnerCount.Should().Be(3);
+            multiSigContract.Required.Should().Be(2);
+            multiSigContract.TransactionCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void IsOwner_NonOwnerAddress_ReturnsFalse()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressFour).Should().BeFalse();
+            multiSigContract.IsOwner(AddressFive).Should().BeFalse();
+            multiSigContract.IsOwner(AddressSix).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// This is important although counter-intuitive. We regard the contract as 'owning' itself,
+        /// but it is not considered one of the individual owner addresses that are allowed to submit and confirm transactions.
+        /// The contract's ownership of itself gives it entirely different privileges that are tested elsewhere.
+        /// </summary>
+        [Fact]
+        public void IsOwner_ContractAddress_ReturnsFalse()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(Contract).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AddOwner_ByContractAddress_Succeeds()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.AddOwner(AddressFour);
+        }
+
+        [Fact]
+        public void AddOwner_ByNonContractAddress_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressFour).Should().BeFalse();
+
+            multiSigContract
+                .Invoking(v => v.AddOwner(AddressFour))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can only be called by the contract itself.");
+        }
+
+        [Fact]
+        public void AddOwner_ForAlreadyExistingOwner_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressOne).Should().BeTrue();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract
+                .Invoking(v => v.AddOwner(AddressOne))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't add an existing owner.");
+        }
+
+        [Fact]
+        public void IsOwner_AfterAddingOwner_ReturnsTrue()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressFour).Should().BeFalse();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.AddOwner(AddressFour);
+
+            multiSigContract.IsOwner(AddressFour).Should().BeTrue();
+        }
+
+        [Fact]
+        public void RemoveOwner_ForNonexistentOwner_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressOne).Should().BeTrue();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract
+                .Invoking(v => v.RemoveOwner(AddressFive))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't remove a non-owner.");
+        }
+
+        [Fact]
+        public void RemoveOwner_ByContractAddress_Succeeds()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.RemoveOwner(AddressOne);
+        }
+
+        [Fact]
+        public void RemoveOwner_ByNonContractAddress_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            multiSigContract
+                .Invoking(v => v.RemoveOwner(AddressOne))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can only be called by the contract itself.");
+        }
+
+        [Fact]
+        public void RemoveOwner_BelowQuorum_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsOwner(AddressOne).Should().BeTrue();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.RemoveOwner(AddressOne);
+
+            multiSigContract
+                .Invoking(v => v.RemoveOwner(AddressTwo))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't have less owners than the minimum confirmation requirement.");
+        }
+
+        [Fact]
+        public void OwnerCount_AfterAddOwner_Increases()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.OwnerCount.Should().Be(3);
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.AddOwner(AddressFour);
+
+            multiSigContract.OwnerCount.Should().Be(4);
+        }
+
+        [Fact]
+        public void OwnerCount_AfterRemoveOwner_Decreases()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.OwnerCount.Should().Be(3);
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.RemoveOwner(AddressOne);
+
+            multiSigContract.OwnerCount.Should().Be(2);
+        }
+
+        [Fact]
+        public void TransactionCount_AfterSubmission_Increases()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            multiSigContract.TransactionCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void Submit_ByOwner_ReturnsTransactionId()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            transactionId.Should().BeGreaterThan(0);
+        }
+
+        [Fact]
+        public void Submit_ByNonOwner_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressFour);
+
+            multiSigContract
+                .Invoking(v => v.Submit(Contract, "TestMethod", new byte[] { }))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Must be one of the contract owners.");
+        }
+
+        [Fact]
+        public void Confirm_WithSameAddressTwice_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            // Note: submission is an implicit confirmation by the submitter
+
+            multiSigContract
+                .Invoking(v => v.Confirm(transactionId))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Sender has already confirmed the transaction.");
+        }
+
+        [Fact]
+        public void Confirm_ByNonOwner_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            SetupMessage(Contract, AddressFour);
+
+            multiSigContract
+                .Invoking(v => v.Confirm(transactionId))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Sender is not authorized to confirm.");
+        }
+
+        [Fact]
+        public void Confirm_ForNonexistentTransaction_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            multiSigContract
+                .Invoking(v => v.Confirm(1))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Transaction ID does not exist.");
+        }
+
+        [Fact]
+        public void IsConfirmedBy_ForSubmittedTransaction_ReturnsTrue()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            // Note: submission is an implicit confirmation by the submitter
+
+            multiSigContract.IsConfirmedBy(transactionId, AddressOne).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsConfirmedBy_ForExecutedTransaction_ReturnsTrue()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            SetupMessage(Contract, AddressTwo);
+
+            multiSigContract.Confirm(transactionId);
+
+            multiSigContract.IsConfirmedBy(transactionId, AddressOne).Should().BeTrue();
+            multiSigContract.IsConfirmedBy(transactionId, AddressTwo).Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsConfirmedBy_ForNonexistentTransaction_ReturnsFalse()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract.IsConfirmedBy(1, AddressOne).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetTransaction_ForNonexistentTransaction_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract
+                .Invoking(v => v.GetTransaction(1))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't retrieve a transaction that doesn't exist yet.");
+        }
+
+        [Fact]
+        public void GetTransaction_AfterSubmittingTransaction_ReturnsTransaction()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            MultisigContract.Transaction result = multiSigContract.GetTransaction(transactionId);
+
+            result.Destination.Should().Be(Contract);
+            result.Executed.Should().BeFalse();
+            result.Value.Should().Be(0);
+            result.MethodName.Should().Be("TestMethod");
+            result.Parameters.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetTransaction_AfterSufficientlyConfirmingTransaction_ReturnsExecutedTransaction()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, AddressOne);
+
+            ulong transactionId = multiSigContract.Submit(Contract, "TestMethod", new byte[] { });
+
+            SetupMessage(Contract, AddressTwo);
+
+            multiSigContract.Confirm(transactionId);
+
+            MultisigContract.Transaction result = multiSigContract.GetTransaction(transactionId);
+
+            result.Destination.Should().Be(Contract);
+            result.Executed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ChangeRequirement_ByContractAddress_Succeeds()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract.ChangeRequirement(3);
+        }
+
+        [Fact]
+        public void ChangeRequirement_ByNonContractAddress_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            multiSigContract
+                .Invoking(v => v.ChangeRequirement(3))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can only be called by the contract itself.");
+        }
+
+        [Fact]
+        public void ChangeRequirement_ToZero_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract
+                .Invoking(v => v.ChangeRequirement(0))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't have a quorum of less than 1.");
+        }
+
+        [Fact]
+        public void ChangeRequirement_HigherThanOwnerCount_Throws()
+        {
+            var multiSigContract = CreateNewMultisigContract();
+
+            SetupMessage(Contract, Contract);
+
+            multiSigContract
+                .Invoking(v => v.ChangeRequirement(4))
+                .Should().Throw<SmartContractAssertException>()
+                .WithMessage("Can't set quorum higher than the number of owners.");
+        }
+    }
+}

--- a/Testnet/Multisig/Multisig.sln
+++ b/Testnet/Multisig/Multisig.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multisig", "Multisig\Multisig.csproj", "{2229FD36-90C8-4A09-A0F2-13A0A8F3BA61}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Multisig.Tests", "Multisig.Tests\Multisig.Tests.csproj", "{6B974B49-456D-463D-9285-0CFE25A42382}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2229FD36-90C8-4A09-A0F2-13A0A8F3BA61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2229FD36-90C8-4A09-A0F2-13A0A8F3BA61}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2229FD36-90C8-4A09-A0F2-13A0A8F3BA61}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2229FD36-90C8-4A09-A0F2-13A0A8F3BA61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B974B49-456D-463D-9285-0CFE25A42382}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B974B49-456D-463D-9285-0CFE25A42382}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B974B49-456D-463D-9285-0CFE25A42382}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B974B49-456D-463D-9285-0CFE25A42382}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {664D2D62-EB97-44A0-9A6A-C6096BE7D717}
+	EndGlobalSection
+EndGlobal

--- a/Testnet/Multisig/Multisig/Multisig.csproj
+++ b/Testnet/Multisig/Multisig/Multisig.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Stratis.SmartContracts" Version="2.0.0" />
+  </ItemGroup>
+  
+</Project>

--- a/Testnet/Multisig/Multisig/MultisigContract.cs
+++ b/Testnet/Multisig/Multisig/MultisigContract.cs
@@ -59,6 +59,11 @@ public class MultisigContract : SmartContract
         return State.GetBool($"{ConfirmationPrefix}:{transactionId}:{address}");
     }
 
+    public uint Confirmations(ulong transactionId)
+    {
+        return State.GetUInt32($"{ConfirmationCountPrefix}:{transactionId}");
+    }
+
     public Transaction GetTransaction(ulong transactionId)
     {
         Assert(transactionId <= TransactionCount, "Can't retrieve a transaction that doesn't exist yet.");
@@ -122,8 +127,10 @@ public class MultisigContract : SmartContract
     /// <summary>
     /// Submits method and parameter metadata describing a contract call that the multisig contract should invoke once it is sufficiently confirmed.
     /// </summary>
+    /// <param name="destination">The address of the contract that the multisig contract will invoke a method on.</param>
+    /// <param name="methodName">The name of the method that the multisig contract will invoke on the destination contract.</param>
     /// <param name="data">An array of method parameters encoded as packed byte arrays. See the <see cref="Transaction"/> struct for further information.</param>
-    /// <returns>The transactionId of the submitted multisig transaction.</returns>
+    /// <returns>The transactionId of the submitted multisig transaction. This is used for confirmation by other multisig nodes, and for looking up execution status etc.</returns>
     /// <remarks>The submitter implicitly provides a confirmation for the submitted transaction.</remarks>
     public ulong Submit(Address destination, string methodName, byte[] data)
     {
@@ -160,7 +167,7 @@ public class MultisigContract : SmartContract
 
         State.SetBool($"{ConfirmationPrefix}:{transactionId}:{Message.Sender}", true);
 
-        uint confirmationCount = State.GetUInt32($"{ConfirmationCountPrefix}:{transactionId}");
+        uint confirmationCount = Confirmations(transactionId);
 
         State.SetUInt32($"{ConfirmationCountPrefix}:{transactionId}", ++confirmationCount);
 

--- a/Testnet/Multisig/Multisig/MultisigContract.cs
+++ b/Testnet/Multisig/Multisig/MultisigContract.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using Stratis.SmartContracts;
+
+[Deploy]
+public class MultisigContract : SmartContract
+{
+    public const string OwnerPrefix = "O";
+    public const string ConfirmationPrefix = "C";
+    public const string ConfirmationCountPrefix = "N";
+    public const string TransactionPrefix = "T";
+
+    public MultisigContract(ISmartContractState smartContractState, byte[] addresses, uint required) : base(smartContractState)
+    {
+        Assert(addresses.Length > 0, "At least one contract owner address must be specified.");
+        Assert(required <= addresses.Length, "The number of required confirmations cannot exceed the number of owners.");
+
+        // We do not store the message sender as an owner; once the contract is deployed only the addresses passed in the constructor can interact with the authenticated contract methods.
+        SetOwners(addresses);
+
+        // This is set after the owners are initially added so that it only needs to be initially set once, rather than after every owner is added.
+        Required = required;
+    }
+    
+    /// <summary>
+    /// The current count of contract owners.
+    /// </summary>
+    public uint OwnerCount
+    {
+        get => State.GetUInt32(nameof(OwnerCount));
+        private set => State.SetUInt32(nameof(OwnerCount), value);
+    }
+
+    /// <summary>
+    /// The number of confirmations required to execute a multisig transaction.
+    /// <remarks>Must be less than or equal to the number of owners at all times.</remarks>
+    /// </summary>
+    public uint Required
+    {
+        get => State.GetUInt32(nameof(Required));
+        private set => State.SetUInt32(nameof(Required), value);
+    }
+
+    /// <summary>
+    /// The transaction counter ensures that each submitted multisig transaction has a unique identifier.
+    /// </summary>
+    public ulong TransactionCount
+    {
+        get => State.GetUInt64(nameof(TransactionCount));
+        private set => State.SetUInt64(nameof(TransactionCount), value);
+    }
+
+    public bool IsOwner(Address address)
+    {
+        return State.GetBool($"{OwnerPrefix}:{address}");
+    }
+
+    public bool IsConfirmedBy(ulong transactionId, Address address)
+    {
+        return State.GetBool($"{ConfirmationPrefix}:{transactionId}:{address}");
+    }
+
+    public Transaction GetTransaction(ulong transactionId)
+    {
+        Assert(transactionId <= TransactionCount, "Can't retrieve a transaction that doesn't exist yet.");
+
+        return State.GetStruct<Transaction>($"{TransactionPrefix}:{transactionId}");
+    }
+    
+    public void AddOwner(Address address)
+    {
+        EnsureWalletOnly();
+
+        Assert(!IsOwner(address), "Can't add an existing owner.");
+
+        SetOwner(address);
+
+        OwnerCount++;
+    }
+
+    public void RemoveOwner(Address address)
+    {
+        EnsureWalletOnly();
+
+        Assert(IsOwner(address), "Can't remove a non-owner.");
+        Assert(OwnerCount > Required, "Can't have less owners than the minimum confirmation requirement.");
+
+        UnsetOwner(address);
+
+        OwnerCount--;
+    }
+
+    /// <summary>
+    /// Only called within the contract constructor to initialise the owners.
+    /// </summary>
+    /// <param name="addresses">The array of addresses serialised as bytes.</param>
+    private void SetOwners(byte[] addresses)
+    {
+        Address[] addressList = Serializer.ToArray<Address>(addresses);
+
+        foreach (var address in addressList)
+        {
+            SetOwner(address);
+        }
+
+        OwnerCount = (uint)addressList.Length;
+    }
+
+    private void SetOwner(Address address)
+    {
+        State.SetBool($"{OwnerPrefix}:{address}", true);
+
+        Log(new OwnerAddition() { Owner = address });
+    }
+
+    private void UnsetOwner(Address address)
+    {
+        State.SetBool($"{OwnerPrefix}:{address}", false);
+
+        Log(new OwnerRemoval() { Owner = address });
+    }
+
+    /// <summary>
+    /// Submits method and parameter metadata describing a contract call that the multisig contract should invoke once it is sufficiently confirmed.
+    /// </summary>
+    /// <param name="data">An array of method parameters encoded as packed byte arrays. See the <see cref="Transaction"/> struct for further information.</param>
+    /// <returns>The transactionId of the submitted multisig transaction.</returns>
+    /// <remarks>The submitter implicitly provides a confirmation for the submitted transaction.</remarks>
+    public ulong Submit(Address destination, string methodName, byte[] data)
+    {
+        EnsureOwnersOnly();
+
+        TransactionCount++;
+
+        State.SetStruct($"{TransactionPrefix}:{TransactionCount}", new Transaction()
+        {
+            Destination = destination,
+            Executed = false,
+            Value = 0,
+            MethodName = methodName,
+            Parameters = data
+        });
+
+        Log(new Submission() { TransactionId = TransactionCount });
+
+        Confirm(TransactionCount);
+
+        return TransactionCount;
+    }
+
+    /// <summary>
+    /// Called by contract owners to indicate that they accept the proposed method invocation provided via <see cref="Submit"/>.
+    /// </summary>
+    /// <param name="transactionId">The transactionId of the submitted multisig transaction.</param>
+    /// <remarks>Once the confirmation count matches or exceeds <see cref="Required"/> the contract call will be executed.</remarks>
+    public void Confirm(ulong transactionId)
+    {
+        Assert(IsOwner(Message.Sender), "Sender is not authorized to confirm.");
+        Assert(transactionId <= TransactionCount, "Transaction ID does not exist.");
+        Assert(!IsConfirmedBy(transactionId, Message.Sender), "Sender has already confirmed the transaction.");
+
+        State.SetBool($"{ConfirmationPrefix}:{transactionId}:{Message.Sender}", true);
+
+        uint confirmationCount = State.GetUInt32($"{ConfirmationCountPrefix}:{transactionId}");
+
+        State.SetUInt32($"{ConfirmationCountPrefix}:{transactionId}", ++confirmationCount);
+
+        Log(new Confirmation() { Sender = Message.Sender, TransactionId = transactionId });
+
+        if (confirmationCount < Required)
+            return;
+
+        // If there were sufficient confirmations then automatically execute the transaction.
+        var tx = State.GetStruct<Transaction>($"{TransactionPrefix}:{transactionId}");
+
+        Assert(!tx.Executed, "Cannot confirm an already-executed transaction.");
+
+        object[] parameters = { };
+
+        if (tx.Parameters != null && tx.Parameters.Length > 0)
+        {
+            byte[][] parametersBytes = Serializer.ToArray<byte[]>(tx.Parameters);
+
+            foreach (byte[] parameter in parametersBytes)
+            {
+                if (parameter == null || parameter.Length == 0)
+                {
+                    continue;
+                }
+
+                int parameterType = (int)parameter[0];
+
+                byte[] parameterEncoded = { };
+
+                Array.Resize(ref parameterEncoded, parameter.Length - 1);
+
+                Array.Copy(parameter, 1, parameterEncoded, 0, parameter.Length - 1);
+
+                object parameterDecoded = null;
+                
+                switch (parameterType)
+                {
+                    case 1: // Boolean
+                        parameterDecoded = Serializer.ToBool(parameterEncoded);
+                        
+                        break;
+                    case 2: // Byte
+                        parameterDecoded = parameterEncoded[0];
+                        
+                        break;
+                    case 3: // Char
+                        parameterDecoded = Serializer.ToChar(parameterEncoded);
+                        
+                        break;
+                    case 4: // String
+                        parameterDecoded = Serializer.ToString(parameterEncoded);
+                        
+                        break;
+                    case 5: // UInt32
+                        parameterDecoded = Serializer.ToUInt32(parameterEncoded);
+                        
+                        break;
+                    case 6: // Int32
+                        parameterDecoded = Serializer.ToInt32(parameterEncoded);
+                        
+                        break;
+                    case 7: // UInt64
+                        parameterDecoded = Serializer.ToUInt64(parameterEncoded);
+                        
+                        break;
+                    case 8: // Int64
+                        parameterDecoded = Serializer.ToInt64(parameterEncoded);
+                        
+                        break;
+                    case 9: // Address
+                        parameterDecoded = Serializer.ToAddress(parameterEncoded);
+                        
+                        break;
+                    case 10: // Byte[]
+                        parameterDecoded = parameterEncoded;
+                        
+                        break;
+                    case 11: // UInt128
+                        parameterDecoded = Serializer.ToUInt128(parameterEncoded);
+                        
+                        break;
+                    case 12: // Uint256
+                        parameterDecoded = Serializer.ToUInt256(parameterEncoded);
+                        
+                        break;
+                    default:
+                        Assert(false, "Unknown parameter type");
+                        break;
+                }
+                
+                int currentLength = parameters.Length;
+                Array.Resize(ref parameters, currentLength + 1);
+                parameters[currentLength] = parameterDecoded;
+            }
+        }
+        
+        ITransferResult result = this.Call(tx.Destination, tx.Value, tx.MethodName, parameters);
+
+        if (result?.Success ?? false)
+            Log(new Execution() { TransactionId = transactionId });
+        else
+            Log(new ExecutionFailure() { TransactionId = transactionId });
+
+        tx.Executed = true;
+
+        State.SetStruct($"{TransactionPrefix}:{transactionId}", tx);
+    }
+
+    public void ChangeRequirement(uint required)
+    {
+        EnsureWalletOnly();
+
+        Assert(required > 0, "Can't have a quorum of less than 1.");
+        Assert(required <= OwnerCount, "Can't set quorum higher than the number of owners.");
+
+        Required = required;
+
+        Log(new RequirementChange() { Requirement = required });
+    }
+
+    /// <summary>
+    /// In the nomenclature of the Gnosis MultisigWallet contract this is based on, the 'wallet' refers to the contract itself.
+    /// In other words, methods with this restriction are intended to only be called by the contract itself.
+    /// </summary>
+    private void EnsureWalletOnly()
+    {
+        Assert(Message.Sender == Message.ContractAddress, "Can only be called by the contract itself.");
+    }
+
+    private void EnsureOwnersOnly()
+    {
+        Assert(IsOwner(Message.Sender), "Must be one of the contract owners.");
+    }
+
+    public struct Transaction
+    {
+        public Address Destination;
+
+        public uint Value;
+
+        public string MethodName;
+
+        /// <summary>
+        /// Array of parameters encoded in packed byte format.
+        /// Internally the array is an array of zero or more byte arrays.
+        /// Each of these sub-arrays consists of a single packed parameter.
+        /// -> The integral value of byte 0 of the packed parameter indicates the parameter's type
+        /// -> The remainder of the packed parameter is a byte array containing the parameter in serialised format
+        /// </summary>
+        public byte[] Parameters;
+
+        public bool Executed;
+    }
+
+    public struct Confirmation
+    {
+        [Index] public Address Sender;
+
+        [Index] public ulong TransactionId;
+    }
+
+    public struct Submission
+    {
+        [Index] public ulong TransactionId;
+    }
+
+    public struct Execution
+    {
+        [Index] public ulong TransactionId;
+    }
+
+    public struct ExecutionFailure
+    {
+        [Index] public ulong TransactionId;
+    }
+
+    public struct OwnerAddition
+    {
+        [Index] public Address Owner;
+    }
+
+    public struct OwnerRemoval
+    {
+        [Index] public Address Owner;
+    }
+
+    public struct RequirementChange
+    {
+        public uint Requirement;
+    }
+}


### PR DESCRIPTION
Perhaps this 'serialised contract call metadata' functionality could be incorporated into a future version of the SmartContracts package.

This is a somewhat complex contract (particularly the `Confirm` method) so careful review is needed.

Based on the Gnosis MultiSigWallet:
https://github.com/gnosis/MultiSigWallet
