### PR TITLE
[TestNet] InterFluxNonFungibleToken

### DIFF
--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/AddressExtensions.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/AddressExtensions.cs
@@ -1,0 +1,42 @@
+﻿using Stratis.SmartContracts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NonFungibleTokenContract.Tests
+{
+    public static class AddressExtensions
+    {
+        private static byte[] HexStringToBytes(string val)
+        {
+            if (val.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                val = val.Substring(2);
+
+            byte[] ret = new byte[val.Length / 2];
+            for (int i = 0; i < val.Length; i = i + 2)
+            {
+                string hexChars = val.Substring(i, 2);
+                ret[i / 2] = byte.Parse(hexChars, System.Globalization.NumberStyles.HexNumber);
+            }
+            return ret;
+        }
+
+        public static Address HexToAddress(this string hexString)
+        {
+            // uint160 only parses a big-endian hex string
+            var result = HexStringToBytes(hexString);
+            return CreateAddress(result);
+        }
+
+        private static Address CreateAddress(byte[] bytes)
+        {
+            uint pn0 = BitConverter.ToUInt32(bytes, 0);
+            uint pn1 = BitConverter.ToUInt32(bytes, 4);
+            uint pn2 = BitConverter.ToUInt32(bytes, 8);
+            uint pn3 = BitConverter.ToUInt32(bytes, 12);
+            uint pn4 = BitConverter.ToUInt32(bytes, 16);
+
+            return new Address(pn0, pn1, pn2, pn3, pn4);
+        }
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InMemoryState.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InMemoryState.cs
@@ -1,0 +1,85 @@
+﻿using Stratis.SmartContracts;
+using System;
+using System.Collections.Generic;
+
+namespace DividendTokenContract.Tests
+{
+    public class InMemoryState : IPersistentState
+    {
+        private readonly Dictionary<string, object> storage = new Dictionary<string, object>();
+        public bool IsContractResult { get; set; }
+        public void Clear(string key) => storage.Remove(key);
+
+        public bool ContainsKey(string key) => storage.ContainsKey(key);
+
+        public T GetValue<T>(string key) => (T)storage.GetValueOrDefault(key, default(T));
+
+        public void AddOrReplace(string key, object value)
+        {
+            if (!storage.TryAdd(key, value))
+                storage[key] = value;
+        }
+        public Address GetAddress(string key) => GetValue<Address>(key);
+
+        public T[] GetArray<T>(string key) => GetValue<T[]>(key);
+
+        public bool GetBool(string key) => GetValue<bool>(key);
+
+        public byte[] GetBytes(byte[] key) => throw new NotImplementedException();
+
+        public byte[] GetBytes(string key) => GetValue<byte[]>(key);
+
+        public char GetChar(string key) => GetValue<char>(key);
+
+        public int GetInt32(string key) => GetValue<int>(key);
+
+        public long GetInt64(string key) => GetValue<long>(key);
+
+        public string GetString(string key) => GetValue<string>(key);
+
+        public T GetStruct<T>(string key)
+                where T : struct => GetValue<T>(key);
+
+        public uint GetUInt32(string key) => GetValue<uint>(key);
+
+        public ulong GetUInt64(string key) => GetValue<ulong>(key);
+
+        public UInt128 GetUInt128(string key) => GetValue<UInt128>(key);
+
+        public UInt256 GetUInt256(string key) => GetValue<UInt256>(key);
+
+        public bool IsContract(Address address) => IsContractResult;
+
+        public void SetAddress(string key, Address value) => AddOrReplace(key, value);
+
+        public void SetArray(string key, Array a) => AddOrReplace(key, a);
+
+        public void SetBool(string key, bool value) => AddOrReplace(key, value);
+
+        public void SetBytes(byte[] key, byte[] value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetBytes(string key, byte[] value) => AddOrReplace(key, value);
+
+        public void SetChar(string key, char value) => AddOrReplace(key, value);
+
+        public void SetInt32(string key, int value) => AddOrReplace(key, value);
+
+        public void SetInt64(string key, long value) => AddOrReplace(key, value);
+
+        public void SetString(string key, string value) => AddOrReplace(key, value);
+
+        public void SetStruct<T>(string key, T value)
+                where T : struct => AddOrReplace(key, value);
+
+        public void SetUInt32(string key, uint value) => AddOrReplace(key, value);
+
+        public void SetUInt64(string key, ulong value) => AddOrReplace(key, value);
+
+        public void SetUInt128(string key, UInt128 value) => AddOrReplace(key, value);
+
+        public void SetUInt256(string key, UInt256 value) => AddOrReplace(key, value);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InterFluxNonFungibleTokenContract.Tests.csproj
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InterFluxNonFungibleTokenContract.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+	<PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InterFluxNonFungibleToken\InterFluxNonFungibleTokenContract.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InterFluxNonFungibleTokenTests.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/InterFluxNonFungibleTokenTests.cs
@@ -1,0 +1,104 @@
+﻿using DividendTokenContract.Tests;
+using Moq;
+using NonFungibleTokenContract.Tests;
+using Stratis.SmartContracts;
+using Xunit;
+
+public class InterFluxNonFungibleTokenTests
+{
+    private Mock<ISmartContractState> smartContractStateMock;
+    private Mock<IContractLogger> contractLoggerMock;
+    private InMemoryState state;
+    private Mock<IInternalTransactionExecutor> transactionExecutorMock;
+    private Address contractAddress;
+    private string name;
+    private string symbol;
+    private bool ownerOnlyMinting;
+    private string nativeChain;
+    private string nativeAddress;
+
+    public InterFluxNonFungibleTokenTests()
+    {
+        this.contractLoggerMock = new Mock<IContractLogger>();
+        this.smartContractStateMock = new Mock<ISmartContractState>();
+        this.transactionExecutorMock = new Mock<IInternalTransactionExecutor>();
+        this.state = new InMemoryState();
+        this.smartContractStateMock.Setup(s => s.PersistentState).Returns(this.state);
+        this.smartContractStateMock.Setup(s => s.ContractLogger).Returns(this.contractLoggerMock.Object);
+        this.smartContractStateMock.Setup(x => x.InternalTransactionExecutor).Returns(this.transactionExecutorMock.Object);
+        this.contractAddress = "0x0000000000000000000000000000000000000001".HexToAddress();
+        this.name = "Non-Fungible Token";
+        this.symbol = "NFT";
+        this.ownerOnlyMinting = true;
+        this.nativeChain = "Ethereum";
+        this.nativeAddress = "0x495f947276749ce646f68ac8c248420045cb7b5e";
+    }
+    
+    [Fact]
+    public void Constructor_Sets_Values()
+    {
+        var owner = "0x0000000000000000000000000000000000000005".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(owner);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.True(state.GetBool("SupportedInterface:1"));
+        Assert.True(state.GetBool("SupportedInterface:2"));
+        Assert.False(state.GetBool("SupportedInterface:3"));
+        Assert.True(state.GetBool("SupportedInterface:4"));
+        Assert.False(state.GetBool("SupportedInterface:5"));
+        Assert.Equal(name, nonFungibleToken.Name);
+        Assert.Equal(symbol, nonFungibleToken.Symbol);
+        Assert.Equal(owner, nonFungibleToken.Owner);
+        Assert.Equal(ownerOnlyMinting, state.GetBool("OwnerOnlyMinting"));
+        Assert.Equal(nativeChain, nonFungibleToken.NativeChain);
+        Assert.Equal(nativeAddress, nonFungibleToken.NativeAddress);
+    }
+
+    [Fact]
+    public void BurnWithMetadata_NoneExistingToken_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.BurnWithMetadata(0, "Metadata"));
+    }
+
+    [Fact]
+    public void BurnWithMetadata_BurningNotOwnedToken_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var anotherTokenOwner = "0x0000000000000000000000000000000000000007".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.SetAddress("IdToOwner:0", anotherTokenOwner);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.BurnWithMetadata(0, "Metadata"));
+    }
+
+    [Fact]
+    public void BurnWithMetadata_BurningAToken_Success()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.BurnWithMetadata(1, "Metadata");
+
+        Assert.Equal(Address.Zero, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Null(nonFungibleToken.TokenURI(1));
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog() { From = ownerAddress, To = Address.Zero, TokenId = 1 }));
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.BurnMetadata() { From = ownerAddress, Amount = 1, Metadata = "Metadata"}));
+    }
+
+    private InterFluxNonFungibleToken CreateNonFungibleToken()
+    {
+        return new InterFluxNonFungibleToken(smartContractStateMock.Object, name, symbol, ownerOnlyMinting, nativeChain, nativeAddress);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/NonFungibleTokenTests.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/NonFungibleTokenTests.cs
@@ -1,0 +1,1204 @@
+﻿using DividendTokenContract.Tests;
+using FluentAssertions;
+using Moq;
+using Moq.Language.Flow;
+using NonFungibleTokenContract.Tests;
+using Stratis.SmartContracts;
+using System;
+using System.Linq;
+using Xunit;
+using static InterFluxNonFungibleToken;
+
+public class NonFungibleTokenTests
+{
+    private Mock<ISmartContractState> smartContractStateMock;
+    private Mock<IContractLogger> contractLoggerMock;
+    private InMemoryState state;
+    private Mock<IInternalTransactionExecutor> transactionExecutorMock;
+    private Address contractAddress;
+    private string name;
+    private string symbol;
+    private bool ownerOnlyMinting;
+
+    public NonFungibleTokenTests()
+    {
+        this.contractLoggerMock = new Mock<IContractLogger>();
+        this.smartContractStateMock = new Mock<ISmartContractState>();
+        this.transactionExecutorMock = new Mock<IInternalTransactionExecutor>();
+        this.state = new InMemoryState();
+        this.smartContractStateMock.Setup(s => s.PersistentState).Returns(this.state);
+        this.smartContractStateMock.Setup(s => s.ContractLogger).Returns(this.contractLoggerMock.Object);
+        this.smartContractStateMock.Setup(x => x.InternalTransactionExecutor).Returns(this.transactionExecutorMock.Object);
+        this.contractAddress = "0x0000000000000000000000000000000000000001".HexToAddress();
+        this.name = "Non-Fungible Token";
+        this.symbol = "NFT";
+        this.ownerOnlyMinting = true;
+    }
+
+    public string GetTokenURI(UInt256 tokenId) => $"https://example.com/api/tokens/{tokenId}";
+
+    [Fact]
+    public void Constructor_Sets_Values()
+    {
+        var owner = "0x0000000000000000000000000000000000000005".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(owner);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.True(state.GetBool("SupportedInterface:1"));
+        Assert.True(state.GetBool("SupportedInterface:2"));
+        Assert.False(state.GetBool("SupportedInterface:3"));
+        Assert.True(state.GetBool("SupportedInterface:4"));
+        Assert.False(state.GetBool("SupportedInterface:5"));
+        Assert.Equal(name, nonFungibleToken.Name);
+        Assert.Equal(symbol, nonFungibleToken.Symbol);
+        Assert.Equal(owner, nonFungibleToken.Owner);
+        Assert.Equal(ownerOnlyMinting, state.GetBool("OwnerOnlyMinting"));
+    }
+
+    [Fact]
+    public void SetPendingOwner_Success()
+    {
+        var owner = "0x0000000000000000000000000000000000000002".HexToAddress();
+        var newOwner = "0x0000000000000000000000000000000000000003".HexToAddress();
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, owner, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SetPendingOwner(newOwner);
+
+        nonFungibleToken.Owner
+                        .Should()
+                        .Be(owner);
+
+        nonFungibleToken.PendingOwner
+                .Should()
+                .Be(newOwner);
+
+        var log = new OwnershipTransferRequestedLog { CurrentOwner = owner, PendingOwner = newOwner };
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), log));
+    }
+
+    [Fact]
+    public void SetPendingOwner_Called_By_NonOwner_Fails()
+    {
+        var owner = "0x0000000000000000000000000000000000000002".HexToAddress();
+        var newOwner = "0x0000000000000000000000000000000000000003".HexToAddress();
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, owner, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, newOwner, 0));
+
+        nonFungibleToken.Invoking(c => c.SetPendingOwner(newOwner))
+                        .Should()
+                        .ThrowExactly<SmartContractAssertException>()
+                        .WithMessage("The method is owner only.");
+    }
+
+    [Fact]
+    public void ClaimOwnership_Not_Called_By_NewOwner_Fails()
+    {
+        var owner = "0x0000000000000000000000000000000000000002".HexToAddress();
+        var newOwner = "0x0000000000000000000000000000000000000003".HexToAddress();
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, owner, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SetPendingOwner(newOwner);
+
+        nonFungibleToken.Invoking(c => c.ClaimOwnership())
+                .Should()
+                .ThrowExactly<SmartContractAssertException>()
+                .WithMessage("ClaimOwnership must be called by the new(pending) owner.");
+    }
+
+    [Fact]
+    public void ClaimOwnership_Success()
+    {
+        var owner = "0x0000000000000000000000000000000000000002".HexToAddress();
+        var newOwner = "0x0000000000000000000000000000000000000003".HexToAddress();
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, owner, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SetPendingOwner(newOwner);
+
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, newOwner, 0));
+
+        nonFungibleToken.ClaimOwnership();
+
+        nonFungibleToken.Owner
+                .Should()
+                .Be(newOwner);
+
+        nonFungibleToken.PendingOwner
+                        .Should()
+                        .Be(Address.Zero);
+
+        var log = new OwnershipTransferedLog { PreviousOwner = owner, NewOwner = newOwner };
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), log));
+    }
+
+    [Fact]
+    public void SupportsInterface_InterfaceSupported_ReturnsTrue()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.SupportsInterface(2);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void SupportsInterface_InterfaceSetToFalseSupported_ReturnsFalse()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+        state.SetBool("SupportedInterface:2", false);
+
+        var result = nonFungibleToken.SupportsInterface(3);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void SupportsInterface_InterfaceNotSupported_ReturnsFalse()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.SupportsInterface(6);
+
+        Assert.False(result);
+    }
+
+
+    [Fact]
+    public void GetApproved_NotValidNFToken_OwnerAddressZero_ThrowsException()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.GetApproved(1));
+    }
+
+    [Fact]
+    public void GetApproved_ApprovalNotInStorage_ReturnsZeroAddress()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+        state.SetAddress("IdToOwner:1", "0x0000000000000000000000000000000000000005".HexToAddress());
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.GetApproved(1);
+
+        Assert.Equal(Address.Zero, result);
+    }
+
+    [Fact]
+    public void GetApproved_ApprovalInStorage_ReturnsAddress()
+    {
+
+        var approvalAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", "0x0000000000000000000000000000000000000005".HexToAddress());
+        state.SetAddress("IdToApproval:1", approvalAddress);
+
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+        var result = nonFungibleToken.GetApproved(1);
+
+        Assert.Equal(approvalAddress, result);
+    }
+
+    [Fact]
+    public void IsApprovedForAll_OwnerToOperatorInStateAsTrue_ReturnsTrue()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddresss = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddresss}", true);
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.IsApprovedForAll(ownerAddress, operatorAddresss);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsApprovedForAll_OwnerToOperatorInStateAsFalse_ReturnsFalse()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddresss = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddresss}", false);
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.IsApprovedForAll(ownerAddress, operatorAddresss);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsApprovedForAll_OwnerToOperatorNotInState_ReturnsFalse()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddresss = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.IsApprovedForAll(ownerAddress, operatorAddresss);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void OwnerOf_IdToOwnerNotInStorage_ThrowsException()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.OwnerOf(1));
+    }
+
+    [Fact]
+    public void OwnerOf_NFTokenMappedToAddressZero_ThrowsException()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        state.SetAddress("IdToOwner:1", Address.Zero);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.OwnerOf(1));
+    }
+
+    [Fact]
+    public void OwnerOf_NFTokenExistsWithOwner_ReturnsOwnerAddress()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.OwnerOf(1);
+
+        Assert.Equal(ownerAddress, result);
+    }
+
+    [Fact]
+    public void BalanceOf_OwnerZero_ThrowsException()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => { nonFungibleToken.BalanceOf(Address.Zero); });
+    }
+
+    [Fact]
+    public void BalanceOf_NftTokenCountNotInStorage_ReturnsZero()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.BalanceOf(ownerAddress);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void BalanceOf_OwnerNftTokenCountInStorage_ReturnsTokenCount()
+    {
+        var sender = "0x0000000000000000000000000000000000000002".HexToAddress();
+        smartContractStateMock.SetupGet(m => m.Message).Returns(new Message(contractAddress, sender, 0));
+
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetUInt256($"Balance:{ownerAddress}", 15);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var result = nonFungibleToken.BalanceOf(ownerAddress);
+
+        Assert.Equal(15, result);
+    }
+
+    [Fact]
+    public void SetApprovalForAll_SetsMessageSender_ToOperatorApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SetApprovalForAll(operatorAddress, true);
+
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.ApprovalForAllLog { Owner = ownerAddress, Operator = operatorAddress, Approved = true }));
+    }
+
+    [Fact]
+    public void Approve_TokenOwnerNotMessageSenderOrOperator_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var someAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Approve(someAddress, 1));
+    }
+
+    [Fact]
+    public void Approve_ValidApproval_SwitchesOwnerToApprovedForNFToken()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var someAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.Approve(someAddress, 1);
+
+        Assert.Equal(state.GetAddress("IdToApproval:1"), someAddress);
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.ApprovalLog { Owner = ownerAddress, Approved = someAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void Approve_NFTokenOwnerSameAsMessageSender_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Approve(ownerAddress, 1));
+    }
+
+    [Fact]
+    public void Approve_ValidApproval_ByApprovedOperator_SwitchesOwnerToApprovedForNFToken()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var someAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.Approve(someAddress, 1);
+
+        Assert.Equal(state.GetAddress("IdToApproval:1"), someAddress);
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.ApprovalLog { Owner = ownerAddress, Approved = someAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void Approve_InvalidNFToken_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var someAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", Address.Zero);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Approve(someAddress, 1));
+    }
+
+    [Fact]
+    public void TransferFrom_ValidTokenTransfer_MessageSender_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.TransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void TransferFrom_NFTokenOwnerZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", Address.Zero);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(Address.Zero);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.TransferFrom(Address.Zero, targetAddress, 1));
+    }
+
+
+    [Fact]
+    public void TransferFrom_ValidTokenTransfer_MessageSenderApprovedForTokenIdByOwner_TransfersTokenFrom_To_ClearsApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var approvalAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetAddress("IdToApproval:1", approvalAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(approvalAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.TransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void TransferFrom_ValidTokenTransfer_MessageSenderApprovedOwnerToOperator_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.TransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void TransferFrom_MessageSenderNotAllowedToCall_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var invalidSenderAddress = "0x0000000000000000000000000000000000000015".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(invalidSenderAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.TransferFrom(ownerAddress, targetAddress, 1));
+    }
+
+    [Fact]
+    public void TransferFrom_TokenDoesNotBelongToFrom_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var notOwningAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.TransferFrom(notOwningAddress, targetAddress, 1));
+    }
+
+    [Fact]
+    public void TransferFrom_ToAddressZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.TransferFrom(ownerAddress, Address.Zero, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractFalse_ValidTokenTransfer_MessageSender_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractFalse_MessageSenderApprovedForTokenIdByOwner_TransfersTokenFrom_To_ClearsApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var approvalAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetAddress("IdToApproval:1", approvalAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(approvalAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractFalse_ValidTokenTransfer_MessageSenderApprovedOwnerToOperator_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractTrue_ContractCallReturnsTrue_ValidTokenTransfer_MessageSender_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        SetupForOnNonFungibleTokenReceived(targetAddress, ownerAddress, ownerAddress, 1).Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance::{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractTrue_ContractCallReturnsTrue_MessageSenderApprovedForTokenIdByOwner_TransfersTokenFrom_To_ClearsApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var approvalAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetAddress("IdToApproval:1", approvalAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(approvalAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        SetupForOnNonFungibleTokenReceived(targetAddress, approvalAddress, ownerAddress, 1).Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractTrue_ContractCallReturnsTrue_ValidTokenTransfer_MessageSenderApprovedOwnerToOperator_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        SetupForOnNonFungibleTokenReceived(targetAddress, operatorAddress, ownerAddress, 1).Returns(TransferResult.Transferred(true));
+
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_MessageSenderNotAllowedToCall_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var invalidSenderAddress = "0x0000000000000000000000000000000000000015".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(invalidSenderAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_NFTokenOwnerZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", Address.Zero);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(Address.Zero);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(Address.Zero, targetAddress, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_TokenDoesNotBelongToFrom_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var notOwningAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(notOwningAddress, targetAddress, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ValidTokenTransfer_ToContractReturnsFalse_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        SetupForOnNonFungibleTokenReceived(targetAddress, ownerAddress, ownerAddress, 1).Returns(TransferResult.Transferred(false));
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1));
+    }
+
+    private IReturnsThrows<IInternalTransactionExecutor, ITransferResult> SetupForOnNonFungibleTokenReceived(Address targetAddress, Address @operator, Address from, UInt256 tokenId)
+    {
+        return transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", It.IsAny<object[]>(), 0ul))
+                                            .Callback<ISmartContractState, Address, ulong, string, object[], ulong>((a, b, c, d, callParams, f) =>
+                                            {
+                                                Assert.True(@operator.Equals(callParams[0]));
+                                                Assert.True(from.Equals(callParams[1]));
+                                                Assert.True(tokenId.Equals(callParams[2]));
+                                                Assert.True(callParams[3] is byte[] bytes && bytes.Length == 0);
+                                            });
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToContractTrue_ContractCallReturnsTruthyObject_CannotCastToBool_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        SetupForOnNonFungibleTokenReceived(targetAddress, ownerAddress, ownerAddress, 1).Returns(TransferResult.Transferred(1));
+
+        Assert.Throws<InvalidCastException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_NoDataProvided_ToAddressZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, Address.Zero, 1));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractFalse_ValidTokenTransfer_MessageSender_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, new byte[1] { 0xff });
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractFalse_MessageSenderApprovedForTokenIdByOwner_TransfersTokenFrom_To_ClearsApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var approvalAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetAddress("IdToApproval:1", approvalAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(approvalAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, new byte[1] { 0xff });
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractFalse_ValidTokenTransfer_MessageSenderApprovedOwnerToOperator_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, new byte[1] { 0xff });
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+
+        transactionExecutorMock.Verify(t => t.Call(It.IsAny<ISmartContractState>(), It.IsAny<Address>(), It.IsAny<ulong>(), "OnNonFungibleTokenReceived", It.IsAny<object[]>(), It.IsAny<ulong>()), Times.Never);
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractTrue_ContractCallReturnsTrue_ValidTokenTransfer_MessageSender_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var data = new byte[] { 12 };
+        var callParamsExpected = new object[] { ownerAddress, ownerAddress, (UInt256)1, data };
+
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", callParamsExpected, 0))
+                                    .Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, data);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractTrue_ContractCallReturnsTrue_MessageSenderApprovedForTokenIdByOwner_TransfersTokenFrom_To_ClearsApproval()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var approvalAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetAddress("IdToApproval:1", approvalAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(approvalAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var data = new byte[] { 12 };
+        var callParamsExpected = new object[] { approvalAddress, ownerAddress, (UInt256)1, data };
+
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", callParamsExpected, 0))
+                                    .Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, data);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractTrue_ContractCallReturnsTrue_ValidTokenTransfer_MessageSenderApprovedOwnerToOperator_TransfersTokenFrom_To()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var operatorAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}", true);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(operatorAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var data = new byte[] { 12 };
+        var callParamsExpected = new object[] { operatorAddress, ownerAddress, (UInt256)1, data };
+
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", callParamsExpected, 0))
+                                    .Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, data);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.True(state.GetBool($"OwnerToOperator:{ownerAddress}:{operatorAddress}"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = ownerAddress, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_MessageSenderNotAllowedToCall_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var invalidSenderAddress = "0x0000000000000000000000000000000000000015".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(invalidSenderAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, new byte[1] { 0xff }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_NFTokenOwnerZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", Address.Zero);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(Address.Zero);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(Address.Zero, targetAddress, 1, new byte[1] { 0xff }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_TokenDoesNotBelongToFrom_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        var notOwningAddress = "0x0000000000000000000000000000000000000008".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(notOwningAddress, targetAddress, 1, new byte[1] { 0xff }));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ValidTokenTransfer_ToContractReturnsFalse_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        var data = new byte[] { 12 };
+        var callParamsExpected = new object[] { ownerAddress, ownerAddress, (UInt256)1, data };
+
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", callParamsExpected, 0))
+                                    .Returns(TransferResult.Transferred(false));
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, data));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToContractTrue_ContractCallReturnsTruthyObject_CannotCastToBool_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.IsContractResult = true;
+        var nonFungibleToken = CreateNonFungibleToken();
+
+
+        var data = new byte[] { 12 };
+        var callParamsExpected = new object[] { ownerAddress, ownerAddress, (UInt256)1, data };
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", callParamsExpected, 0))
+                                    .Returns(TransferResult.Transferred(1));
+
+        Assert.Throws<InvalidCastException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, targetAddress, 1, data));
+    }
+
+    [Fact]
+    public void SafeTransferFrom_DataProvided_ToAddressZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.SafeTransferFrom(ownerAddress, Address.Zero, 1, new byte[1] { 0xff }));
+    }
+
+    [Fact]
+    public void Mint_CalledByNonOwner_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var userAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(userAddress);
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Mint(userAddress, (UInt256)1, GetTokenURI(1)));
+    }
+
+    [Fact]
+    public void Mint_ToAdressZero_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Mint(Address.Zero, (UInt256)1, GetTokenURI(1)));
+    }
+
+    [Fact]
+    public void Mint_MintingNewToken_Called_By_None_Owner_When_OwnerOnlyMintingFalse_Success()
+    {
+        ownerOnlyMinting = false;
+
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(targetAddress);
+        nonFungibleToken.Mint(targetAddress, (UInt256)1, GetTokenURI(1));
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+        Assert.Equal(GetTokenURI(1), nonFungibleToken.TokenURI(1));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = Address.Zero, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void Mint_MintingNewToken_Success()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.Mint(targetAddress, (UInt256)1, GetTokenURI(1));
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+        Assert.Equal(GetTokenURI(1), nonFungibleToken.TokenURI(1));
+        Assert.Null(nonFungibleToken.TokenURI(2));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = Address.Zero, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void SafeMint_MintingNewToken_When_Destination_Is_Contract_Success()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var targetAddress = "0x0000000000000000000000000000000000000007".HexToAddress();
+        state.IsContractResult = true;
+
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+        var data = new byte[] { 12 };
+        var parameter = new object[] { ownerAddress, Address.Zero, (UInt256)1, data };
+        transactionExecutorMock.Setup(t => t.Call(It.IsAny<ISmartContractState>(), targetAddress, 0, "OnNonFungibleTokenReceived", parameter, 0))
+                                    .Returns(TransferResult.Transferred(true));
+
+        nonFungibleToken.SafeMint(targetAddress, (UInt256)1, GetTokenURI(1), data);
+
+        Assert.Equal(targetAddress, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(1, state.GetUInt256($"Balance:{targetAddress}"));
+        Assert.Equal(GetTokenURI(1), nonFungibleToken.TokenURI(1));
+        Assert.Null(nonFungibleToken.TokenURI(2));
+
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog { From = Address.Zero, To = targetAddress, TokenId = 1 }));
+    }
+
+    [Fact]
+    public void Burn_NoneExistingToken_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Burn(0));
+    }
+
+    [Fact]
+    public void Burn_BurningNotOwnedToken_ThrowsException()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        var anotherTokenOwner = "0x0000000000000000000000000000000000000007".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.SetAddress("IdToOwner:0", anotherTokenOwner);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        Assert.Throws<SmartContractAssertException>(() => nonFungibleToken.Burn(0));
+    }
+
+    [Fact]
+    public void Burn_BurningAToken_Success()
+    {
+        var ownerAddress = "0x0000000000000000000000000000000000000006".HexToAddress();
+        smartContractStateMock.Setup(m => m.Message.Sender).Returns(ownerAddress);
+        state.SetAddress("IdToOwner:1", ownerAddress);
+        state.SetUInt256($"Balance:{ownerAddress}", 1);
+
+        var nonFungibleToken = CreateNonFungibleToken();
+
+        nonFungibleToken.Burn(1);
+
+        Assert.Equal(Address.Zero, state.GetAddress("IdToOwner:1"));
+        Assert.Equal(0, state.GetUInt256($"Balance:{ownerAddress}"));
+        Assert.Null(nonFungibleToken.TokenURI(1));
+        contractLoggerMock.Verify(l => l.Log(It.IsAny<ISmartContractState>(), new InterFluxNonFungibleToken.TransferLog() { From = ownerAddress, To = Address.Zero, TokenId = 1 }));
+    }
+
+    private InterFluxNonFungibleToken CreateNonFungibleToken()
+    {
+        return new InterFluxNonFungibleToken(smartContractStateMock.Object, name, symbol, ownerOnlyMinting, "Ethereum", "0x495f947276749ce646f68ac8c248420045cb7b5e");
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/TransferResult.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken.Tests/TransferResult.cs
@@ -1,0 +1,16 @@
+﻿using Stratis.SmartContracts;
+
+namespace NonFungibleTokenContract.Tests
+{
+    public class TransferResult : ITransferResult
+    {
+        public object ReturnValue { get; private set; }
+
+        public bool Success { get; private set; }
+
+        public static TransferResult Failed() => new TransferResult { Success = false };
+
+
+        public static TransferResult Transferred(object returnValue) => new TransferResult { Success = true, ReturnValue = returnValue };
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/IBurnableWithMetadata.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/IBurnableWithMetadata.cs
@@ -1,0 +1,18 @@
+﻿using Stratis.SmartContracts;
+
+/// <summary>
+/// An extension of the IBurnable functionality that allows additional data (e.g. for tagging) to be recorded.
+/// </summary>
+public interface IBurnableWithMetadata
+{
+    /// <summary>
+    /// A user can burn tokens if they are the owner of the token.
+    /// Burnt tokens are permanently removed from the total supply and cannot be retrieved.
+    /// </summary>
+    /// <remarks>Emits a TransferLog event with the 'to' address set to the zero address.
+    /// Additionally emits a BurnMetadata event containing the metadata string.</remarks>
+    /// <param name="amount">The quantity of tokens to be burnt.</param>
+    /// <param name="metadata">Additional data to be recorded with the burn.
+    /// The structure and interpretation of this data is unspecified here.</param>
+    void BurnWithMetadata(UInt256 amount, string metadata);
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleToken.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleToken.cs
@@ -1,0 +1,99 @@
+﻿namespace NonFungibleTokenContract
+{
+    using Stratis.SmartContracts;
+
+    /// <summary>
+    /// Interface for a non-fungible token.
+    /// </summary>
+    public interface INonFungibleToken
+    {
+        /// <summary>
+        /// Transfers the ownership of an NFT from one address to another address. This function can
+        /// be changed to payable.
+        /// </summary>
+        /// <remarks>Throws unless <see cref="Message.Sender"/> is the current owner, an authorized operator, or the
+        /// approved address for this NFT.Throws if 'from' is not the current owner.Throws if 'to' is
+        /// the zero address.Throws if 'tokenId' is not a valid NFT. When transfer is complete, this
+        /// function checks if 'to' is a smart contract. If so, it calls
+        /// 'OnNonFungibleTokenReceived' on 'to' and throws if the return value true.</remarks>
+        /// <param name="from">The current owner of the NFT.</param>
+        /// <param name="to">The new owner.</param>
+        /// <param name="tokenId">The NFT to transfer.</param>
+        /// <param name="data">Additional data with no specified format, sent in call to 'to'.</param>
+        void SafeTransferFrom(Address from, Address to, UInt256 tokenId, byte[] data);
+
+        /// <summary>
+        /// Transfers the ownership of an NFT from one address to another address. This function can
+        /// be changed to payable.
+        /// </summary>
+        /// <remarks>This works identically to the other function with an extra data parameter, except this
+        /// function just sets data to an empty byte array.</remarks>
+        /// <param name="from">The current owner of the NFT.</param>
+        /// <param name="to">The new owner.</param>
+        /// <param name="tokenId">The NFT to transfer.</param>
+        void SafeTransferFrom(Address from, Address to, UInt256 tokenId);
+
+        /// <summary>
+        /// Throws unless <see cref="Message.Sender"/> is the current owner, an authorized operator, or the approved
+        /// address for this NFT.Throws if <see cref="from"/> is not the current owner.Throws if <see cref="to"/> is the zero
+        /// address.Throws if <see cref="tokenId"/> is not a valid NFT. This function can be changed to payable.
+        /// </summary>
+        /// <remarks>The caller is responsible to confirm that <see cref="to"/> is capable of receiving NFTs or else
+        /// they maybe be permanently lost.</remarks>
+        /// <param name="from">The current owner of the NFT.</param>
+        /// <param name="to">The new owner.</param>
+        /// <param name="tokenId">The NFT to transfer.</param>
+        void TransferFrom(Address from, Address to, UInt256 tokenId);
+
+        /// <summary>
+        /// Set or reaffirm the approved address for an NFT. This function can be changed to payable.
+        /// </summary>
+        /// <remarks>
+        /// The zero address indicates there is no approved address. Throws unless <see cref="Message.Sender"/> is
+        /// the current NFT owner, or an authorized operator of the current owner.
+        /// </remarks>
+        /// <param name="approved">Address to be approved for the given NFT ID.</param>
+        /// <param name="tokenId">ID of the token to be approved.</param>
+        void Approve(Address approved, UInt256 tokenId);
+
+        /// <summary>
+        /// Enables or disables approval for a third party ("operator") to manage all of
+        /// <see cref="Message.Sender"/>'s assets. It also Logs the ApprovalForAll event.
+        /// </summary>
+        /// <remarks>This works even if sender doesn't own any tokens at the time.</remarks>
+        /// <param name="operatorAddress">Address to add to the set of authorized operators.</param>
+        /// <param name="approved">True if the operators is approved, false to revoke approval.</param>
+        void SetApprovalForAll(Address operatorAddress, bool approved);
+
+        /// <summary>
+        /// Returns the number of NFTs owned by 'owner'. NFTs assigned to the zero address are
+        /// considered invalid, and this function throws for queries about the zero address.
+        /// </summary>
+        /// <param name="owner">Address for whom to query the balance.</param>
+        /// <returns>Balance of owner.</returns>
+        UInt256 BalanceOf(Address owner);
+
+        /// <summary>
+        /// Returns the address of the owner of the NFT. NFTs assigned to zero address are considered invalid, and queries about them do throw.
+        /// </summary>
+        /// <param name="tokenId">The identifier for an NFT.</param>
+        /// <returns>Address of tokenId owner.</returns>
+        Address OwnerOf(UInt256 tokenId);
+
+        /// <summary>
+        /// Get the approved address for a single NFT.
+        /// </summary>
+        /// <remarks>Throws if 'tokenId' is not a valid NFT.</remarks>
+        /// <param name="tokenId">ID of the NFT to query the approval of.</param>
+        /// <returns>Address that tokenId is approved for. </returns>
+        Address GetApproved(UInt256 tokenId);
+
+        /// <summary>
+        /// Checks if 'operator' is an approved operator for 'owner'.
+        /// </summary>
+        /// <param name="owner">The address that owns the NFTs.</param>
+        /// <param name="operatorAddress">The address that acts on behalf of the owner.</param>
+        /// <returns>True if approved for all, false otherwise.</returns>
+        bool IsApprovedForAll(Address owner, Address operatorAddress);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleTokenMetadata.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleTokenMetadata.cs
@@ -1,0 +1,12 @@
+﻿using Stratis.SmartContracts;
+
+namespace NonFungibleTokenContract
+{
+    public interface INonFungibleTokenMetadata
+    {
+        string Name { get; }
+        string Symbol { get; }
+
+        string TokenURI(UInt256 tokenId);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleTokenReceiver.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/INonFungibleTokenReceiver.cs
@@ -1,0 +1,22 @@
+﻿namespace NonFungibleTokenContract
+{
+    using Stratis.SmartContracts;
+
+    /// <summary>
+    /// Interface for a non-fungible token receiver.
+    /// </summary>
+    public interface INonFungibleTokenReceiver
+    {
+        /// <summary>
+        /// Handle the receipt of a NFT. The smart contract calls this function on the
+        /// recipient after a transfer. This function MAY throw or return false to revert and reject the transfer.
+        /// Return true if the transfer is ok.
+        /// </summary>
+        /// <param name="operatorAddress">The address which called safeTransferFrom function.</param>
+        /// <param name="fromAddress">The address which previously owned the token.</param>
+        /// <param name="tokenId">The NFT identifier which is being transferred.</param>
+        /// <param name="data">Additional data with no specified format.</param>
+        /// <returns>A bool indicating the resulting operation.</returns>
+        bool OnNonFungibleTokenReceived(Address operatorAddress, Address fromAddress, UInt256 tokenId, byte[] data);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/ISupportsInterface.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/ISupportsInterface.cs
@@ -1,0 +1,15 @@
+﻿namespace NonFungibleTokenContract
+{
+    /// <summary>
+    /// Interface for a class with interface indication support.
+    /// </summary>
+    public interface ISupportsInterface
+    {
+        /// <summary>
+        /// Function to check which interfaces are supported by this contract.
+        /// </summary>
+        /// <param name="interfaceID">Id of the interface.</param>
+        /// <returns>True if <see cref="interfaceID"/> is supported, false otherwise.</returns>
+        bool SupportsInterface(uint interfaceID);
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/InterFluxNonFungibleToken.cs
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/InterFluxNonFungibleToken.cs
@@ -1,0 +1,648 @@
+﻿using Stratis.SmartContracts;
+/// <summary>
+/// A non fungible token contract.
+/// </summary>
+public class InterFluxNonFungibleToken : SmartContract, IBurnableWithMetadata
+{
+    /// <summary>
+    /// Function to check which interfaces are supported by this contract.
+    /// </summary>
+    /// <param name="interfaceID">Id of the interface.</param>
+    /// <returns>True if <see cref="interfaceID"/> is supported, false otherwise.</returns>
+    public bool SupportsInterface(uint interfaceID)
+    {
+        return State.GetBool($"SupportedInterface:{interfaceID}");
+    }
+
+    /// <summary>
+    /// Sets the supported interface value.
+    /// </summary>
+    /// <param name="interfaceId">The interface id.</param>
+    /// <param name="value">A value indicating if the interface id is supported.</param>
+    private void SetSupportedInterfaces(TokenInterface interfaceId, bool value) => State.SetBool($"SupportedInterface:{(uint)interfaceId}", value);
+
+    /// <summary>
+    /// Gets the key to the persistent state for the owner by NFT ID.
+    /// </summary>
+    /// <param name="id">The NFT ID.</param>
+    /// <returns>The persistent storage key to get or set the NFT owner.</returns>
+    private string GetIdToOwnerKey(UInt256 id) => $"IdToOwner:{id}";
+
+    ///<summary>
+    /// Gets the address of the owner of the NFT ID. 
+    ///</summary>
+    /// <param name="id">The ID of the NFT</param>
+    ///<returns>The owner address.</returns>
+    private Address GetIdToOwner(UInt256 id) => State.GetAddress(GetIdToOwnerKey(id));
+
+    /// <summary>
+    /// Sets the owner to the NFT ID.
+    /// </summary>
+    /// <param name="id">The ID of the NFT</param>
+    /// <param name="value">The address of the owner.</param>
+    private void SetIdToOwner(UInt256 id, Address value) => State.SetAddress(GetIdToOwnerKey(id), value);
+
+    /// <summary>
+    /// Gets the key to the persistent state for the approval address by NFT ID.
+    /// </summary>
+    /// <param name="id">The NFT ID.</param>
+    /// <returns>The persistent storage key to get or set the NFT approval.</returns>
+    private string GetIdToApprovalKey(UInt256 id) => $"IdToApproval:{id}";
+
+    /// <summary>
+    /// Getting from NFT ID the approval address.
+    /// </summary>
+    /// <param name="id">The ID of the NFT</param>
+    /// <returns>Address of the approval.</returns>
+    private Address GetIdToApproval(UInt256 id) => State.GetAddress(GetIdToApprovalKey(id));
+
+    /// <summary>
+    /// Setting to NFT ID to approval address.
+    /// </summary>
+    /// <param name="id">The ID of the NFT</param>
+    /// <param name="value">The address of the approval.</param>
+    private void SetIdToApproval(UInt256 id, Address value) => State.SetAddress(GetIdToApprovalKey(id), value);
+
+    /// <summary>
+    /// Gets the amount of non fungible tokens the owner has.
+    /// </summary>
+    /// <param name="address">The address of the owner.</param>
+    /// <returns>The amount of non fungible tokens.</returns>
+    private UInt256 GetBalance(Address address) => State.GetUInt256($"Balance:{address}");
+
+    /// <summary>
+    /// Sets the owner count of this non fungible tokens.
+    /// </summary>
+    /// <param name="address">The address of the owner.</param>
+    /// <param name="value">The amount of tokens.</param>
+    private void SetBalance(Address address, UInt256 value) => State.SetUInt256($"Balance:{address}", value);
+
+    /// <summary>
+    /// Gets the permission value of the operator authorization to perform actions on behalf of the owner.
+    /// </summary>
+    /// <param name="owner">The owner address of the NFT.</param>
+    /// <param name="operatorAddress">>Address of the authorized operators</param>
+    /// <returns>A value indicating if the operator has permissions to act on behalf of the owner.</returns>
+    private bool GetOwnerToOperator(Address owner, Address operatorAddress) => State.GetBool($"OwnerToOperator:{owner}:{operatorAddress}");
+
+    /// <summary>
+    /// Sets the owner to operator permission.
+    /// </summary>
+    /// <param name="owner">The owner address of the NFT.</param>
+    /// <param name="operatorAddress">>Address to add to the set of authorized operators.</param>
+    /// <param name="value">The permission value.</param>
+    private void SetOwnerToOperator(Address owner, Address operatorAddress, bool value) => State.SetBool($"OwnerToOperator:{owner}:{operatorAddress}", value);
+
+    /// <summary>
+    /// Owner of the contract is responsible to for minting/burning 
+    /// </summary>
+    public Address Owner
+    {
+        get => State.GetAddress(nameof(Owner));
+        private set => State.SetAddress(nameof(Owner), value);
+    }
+
+    /// <summary>
+    /// Claimed new owner 
+    /// </summary>
+    public Address PendingOwner
+    {
+        get => State.GetAddress(nameof(PendingOwner));
+        private set => State.SetAddress(nameof(PendingOwner), value);
+    }
+
+    /// <summary>
+    /// Name for non-fungible token contract
+    /// </summary>
+    public string Name
+    {
+        get => State.GetString(nameof(Name));
+        private set => State.SetString(nameof(Name), value);
+    }
+
+    /// <summary>
+    /// Symbol for non-fungible token contract
+    /// </summary>
+    public string Symbol
+    {
+        get => State.GetString(nameof(Symbol));
+        private set => State.SetString(nameof(Symbol), value);
+    }
+
+    private string GetIdToTokenURI(UInt256 tokenId) => State.GetString($"URI:{tokenId}");
+    private void SetIdToTokenURI(UInt256 tokenId, string uri) => State.SetString($"URI:{tokenId}", uri);
+
+    private bool OwnerOnlyMinting
+    {
+        get => State.GetBool(nameof(OwnerOnlyMinting));
+        set => State.SetBool(nameof(OwnerOnlyMinting), value);
+    }
+
+    public string NativeChain
+    {
+        get => State.GetString(nameof(this.NativeChain));
+        private set => State.SetString(nameof(this.NativeChain), value);
+    }
+
+    public string NativeAddress
+    {
+        get => State.GetString(nameof(this.NativeAddress));
+        private set => State.SetString(nameof(this.NativeAddress), value);
+    }
+
+    /// <summary>
+    /// Constructor used to create a new instance of the non-fungible token.
+    /// </summary>
+    /// <param name="state">The execution state for the contract.</param>
+    /// <param name="name">Name of the NFT Contract</param>
+    /// <param name="symbol">Symbol of the NFT Contract</param>
+    /// <param name="ownerOnlyMinting">True, if only owner allowed to mint tokens</param>
+    /// <param name="nativeChain">The blockchain name of the token's native chain.</param>
+    /// <param name="nativeAddress">The contract address on the token's native blockchain if available.</param>
+    public InterFluxNonFungibleToken(ISmartContractState state, string name, string symbol, bool ownerOnlyMinting, string nativeChain, string nativeAddress) : base(state)
+    {
+        this.SetSupportedInterfaces(TokenInterface.ISupportsInterface, true); // (ERC165) - ISupportsInterface
+        this.SetSupportedInterfaces(TokenInterface.INonFungibleToken, true); // (ERC721) - INonFungibleToken,
+        this.SetSupportedInterfaces(TokenInterface.INonFungibleTokenReceiver, false); // (ERC721) - INonFungibleTokenReceiver
+        this.SetSupportedInterfaces(TokenInterface.INonFungibleTokenMetadata, true); // (ERC721) - INonFungibleTokenMetadata
+        this.SetSupportedInterfaces(TokenInterface.INonFungibleTokenEnumerable, false); // (ERC721) - INonFungibleTokenEnumerable
+
+        this.Name = name;
+        this.Symbol = symbol;
+        this.Owner = Message.Sender;
+        this.OwnerOnlyMinting = ownerOnlyMinting;
+        this.NativeChain = nativeChain;
+        this.NativeAddress = nativeAddress;
+    }
+
+    /// <summary>
+    /// Transfers the ownership of an NFT from one address to another address. This function can
+    /// be changed to payable.
+    /// </summary>
+    /// <remarks>Throws unless <see cref="Message.Sender"/> is the current owner, an authorized operator, or the
+    /// approved address for this NFT.Throws if 'from' is not the current owner.Throws if 'to' is
+    /// the zero address.Throws if 'tokenId' is not a valid NFT. When transfer is complete, this
+    /// function checks if 'to' is a smart contract. If so, it calls
+    /// 'OnNonFungibleTokenReceived' on 'to' and throws if the return value true.</remarks>
+    /// <param name="from">The current owner of the NFT.</param>
+    /// <param name="to">The new owner.</param>
+    /// <param name="tokenId">The NFT to transfer.</param>
+    /// <param name="data">Additional data with no specified format, sent in call to 'to'.</param>
+    public void SafeTransferFrom(Address from, Address to, UInt256 tokenId, byte[] data)
+    {
+        SafeTransferFromInternal(from, to, tokenId, data);
+    }
+
+    /// <summary>
+    /// Transfers the ownership of an NFT from one address to another address. This function can
+    /// be changed to payable.
+    /// </summary>
+    /// <remarks>This works identically to the other function with an extra data parameter, except this
+    /// function just sets data to an empty byte array.</remarks>
+    /// <param name="from">The current owner of the NFT.</param>
+    /// <param name="to">The new owner.</param>
+    /// <param name="tokenId">The NFT to transfer.</param>
+    public void SafeTransferFrom(Address from, Address to, UInt256 tokenId)
+    {
+        SafeTransferFromInternal(from, to, tokenId, new byte[0]);
+    }
+
+    /// <summary>
+    /// Throws unless <see cref="Message.Sender"/> is the current owner, an authorized operator, or the approved
+    /// address for this NFT.
+    /// Throws if <see cref="from"/> is not the current owner.
+    /// Throws if <see cref="to"/> is the zero address.
+    /// Throws if <see cref="tokenId"/> is not a valid NFT.
+    /// </summary>
+    /// <remarks>The caller is responsible to confirm that <see cref="to"/> is capable of receiving NFTs or else
+    /// they maybe be permanently lost.</remarks>
+    /// <param name="from">The current owner of the NFT.</param>
+    /// <param name="to">The new owner.</param>
+    /// <param name="tokenId">The NFT to transfer.</param>
+    public void TransferFrom(Address from, Address to, UInt256 tokenId)
+    {
+        EnsureAddressIsNotEmpty(to);
+        Address tokenOwner = GetIdToOwner(tokenId);
+
+        EnsureAddressIsNotEmpty(tokenOwner);
+        CanTransfer(tokenOwner, tokenId);
+
+        Assert(tokenOwner == from, "The from parameter is not token owner.");
+
+        TransferInternal(tokenOwner, to, tokenId);
+    }
+
+    /// <summary>
+    /// Set or reaffirm the approved address for an NFT. This function can be changed to payable.
+    /// </summary>
+    /// <remarks>
+    /// The zero address indicates there is no approved address. Throws unless <see cref="Message.Sender"/> is
+    /// the current NFT owner, or an authorized operator of the current owner.
+    /// </remarks>
+    /// <param name="approved">Address to be approved for the given NFT ID.</param>
+    /// <param name="tokenId">ID of the token to be approved.</param>
+    public void Approve(Address approved, UInt256 tokenId)
+    {
+        Address tokenOwner = GetIdToOwner(tokenId);
+
+        EnsureAddressIsNotEmpty(tokenOwner);
+
+        CanOperate(tokenOwner);
+
+        Assert(approved != tokenOwner, $"The {nameof(approved)} address is already token owner.");
+
+        SetIdToApproval(tokenId, approved);
+        LogApproval(tokenOwner, approved, tokenId);
+    }
+
+    /// <summary>
+    /// Enables or disables approval for a third party ("operator") to manage all of
+    /// <see cref="Message.Sender"/>'s assets. It also Logs the ApprovalForAll event.
+    /// </summary>
+    /// <remarks>This works even if sender doesn't own any tokens at the time.</remarks>
+    /// <param name="operatorAddress">Address to add to the set of authorized operators.</param>
+    /// <param name="approved">True if the operators is approved, false to revoke approval.</param>
+    public void SetApprovalForAll(Address operatorAddress, bool approved)
+    {
+        SetOwnerToOperator(Message.Sender, operatorAddress, approved);
+        LogApprovalForAll(Message.Sender, operatorAddress, approved);
+    }
+
+    /// <summary>
+    /// Returns the number of NFTs owned by 'owner'. NFTs assigned to the zero address are
+    /// considered invalid, and this function throws for queries about the zero address.
+    /// </summary>
+    /// <param name="owner">Address for whom to query the balance.</param>
+    /// <returns>Balance of owner.</returns>
+    public UInt256 BalanceOf(Address owner)
+    {
+        EnsureAddressIsNotEmpty(owner);
+        return GetBalance(owner);
+    }
+
+    /// <summary>
+    /// Returns the address of the owner of the NFT. NFTs assigned to zero address are considered invalid, and queries about them do throw.
+    /// </summary>
+    /// <param name="tokenId">The identifier for an NFT.</param>
+    /// <returns>Address of tokenId owner.</returns>
+    public Address OwnerOf(UInt256 tokenId)
+    {
+        Address owner = GetIdToOwner(tokenId);
+        EnsureAddressIsNotEmpty(owner);
+        return owner;
+    }
+
+    /// <summary>
+    /// Get the approved address for a single NFT.
+    /// </summary>
+    /// <remarks>Throws if 'tokenId' is not a valid NFT.</remarks>
+    /// <param name="tokenId">ID of the NFT to query the approval of.</param>
+    /// <returns>Address that tokenId is approved for. </returns>
+    public Address GetApproved(UInt256 tokenId)
+    {
+        Address tokenOwner = GetIdToOwner(tokenId);
+
+        EnsureAddressIsNotEmpty(tokenOwner);
+
+        return GetIdToApproval(tokenId);
+    }
+
+    /// <summary>
+    /// Checks if 'operator' is an approved operator for 'owner'.
+    /// </summary>
+    /// <param name="owner">The address that owns the NFTs.</param>
+    /// <param name="operatorAddress">The address that acts on behalf of the owner.</param>
+    /// <returns>True if approved for all, false otherwise.</returns>
+    public bool IsApprovedForAll(Address owner, Address operatorAddress)
+    {
+        return GetOwnerToOperator(owner, operatorAddress);
+    }
+
+    /// <summary>
+    /// Actually performs the transfer.
+    /// </summary>
+    /// <remarks>Does NO checks.</remarks>
+    /// <param name="from">The current owner of the NFT.</param>
+    /// <param name="to">Address of a new owner.</param>
+    /// <param name="tokenId">The NFT that is being transferred.</param>
+    private void TransferInternal(Address from, Address to, UInt256 tokenId)
+    {
+        ClearApproval(tokenId);
+
+        RemoveToken(from, tokenId);
+        AddToken(to, tokenId);
+
+        LogTransfer(from, to, tokenId);
+    }
+
+    /// <summary>
+    /// Removes a NFT from owner.
+    /// </summary>
+    /// <remarks>Use and override this function with caution. Wrong usage can have serious consequences.</remarks>
+    /// <param name="from">Address from wich we want to remove the NFT.</param>
+    /// <param name="tokenId">Which NFT we want to remove.</param>
+    private void RemoveToken(Address from, UInt256 tokenId)
+    {
+        var tokenCount = GetBalance(from);
+        SetBalance(from, tokenCount - 1);
+        SetIdToOwner(tokenId, Address.Zero);
+    }
+
+    /// <summary>
+    /// Assignes a new NFT to owner.
+    /// </summary>
+    /// <remarks>Use and override this function with caution. Wrong usage can have serious consequences.</remarks>
+    /// <param name="to">Address to which we want to add the NFT.</param>
+    /// <param name="tokenId">Which NFT we want to add.</param>
+    private void AddToken(Address to, UInt256 tokenId)
+    {
+        SetIdToOwner(tokenId, to);
+        var currentTokenAmount = GetBalance(to);
+        SetBalance(to, currentTokenAmount + 1);
+    }
+
+    /// <summary>
+    /// Actually perform the safeTransferFrom.
+    /// </summary>
+    /// <param name="from">The current owner of the NFT.</param>
+    /// <param name="to">The new owner.</param>
+    /// <param name="tokenId">The NFT to transfer.</param>
+    /// <param name="data">Additional data with no specified format, sent in call to 'to' if it is a contract.</param>
+    private void SafeTransferFromInternal(Address from, Address to, UInt256 tokenId, byte[] data)
+    {
+        TransferFrom(from, to, tokenId);
+
+        EnsureContractReceivedToken(from, to, tokenId, data);
+    }
+
+    /// <summary>
+    /// Clears the current approval of a given NFT ID.
+    /// </summary>
+    /// <param name="tokenId">ID of the NFT to be transferred</param>
+    private void ClearApproval(UInt256 tokenId)
+    {
+        if (GetIdToApproval(tokenId) != Address.Zero)
+        {
+            SetIdToApproval(tokenId, Address.Zero);
+        }
+    }
+
+    /// <summary>
+    /// This logs when ownership of any NFT changes by any mechanism. This event logs when NFTs are
+    /// created('from' == 0) and destroyed('to' == 0). Exception: during contract creation, any
+    /// number of NFTs may be created and assigned without logging Transfer.At the time of any
+    /// transfer, the approved Address for that NFT (if any) is reset to none.
+    /// </summary>
+    /// <param name="from">The from address.</param>
+    /// <param name="to">The to address.</param>
+    /// <param name="tokenId">The NFT ID.</param>
+    private void LogTransfer(Address from, Address to, UInt256 tokenId)
+    {
+        Log(new TransferLog() { From = from, To = to, TokenId = tokenId });
+    }
+
+    /// <summary>
+    /// This logs when the approved Address for an NFT is changed or reaffirmed. The zero
+    /// Address indicates there is no approved Address. When a Transfer logs, this also
+    /// indicates that the approved Address for that NFT (if any) is reset to none.
+    /// </summary>
+    /// <param name="owner">The owner address.</param>
+    /// <param name="operatorAddress">The approved address.</param>
+    /// <param name="tokenId">The NFT ID.</param>
+    private void LogApproval(Address owner, Address approved, UInt256 tokenId)
+    {
+        Log(new ApprovalLog() { Owner = owner, Approved = approved, TokenId = tokenId });
+    }
+
+    /// <summary>
+    /// This logs when an operator is enabled or disabled for an owner. The operator can manage all NFTs of the owner.
+    /// </summary>
+    /// <param name="owner">The owner address</param>
+    /// <param name="operatorAddress">The operator address.</param>
+    /// <param name="approved">A boolean indicating if it has been approved.</param>        
+    private void LogApprovalForAll(Address owner, Address operatorAddress, bool approved)
+    {
+        Log(new ApprovalForAllLog() { Owner = owner, Operator = operatorAddress, Approved = approved });
+    }
+
+
+    /// <summary>
+    /// Guarantees that the <see cref="Message.Sender"/> is an owner or operator of the given NFT.
+    /// </summary>
+    /// <param name="tokenId">ID of the NFT to validate.</param>
+    private void CanOperate(Address tokenOwner)
+    {
+        Assert(IsOwnerOrOperator(tokenOwner), "Caller is not owner nor approved.");
+    }
+
+    private bool IsOwnerOrOperator(Address tokenOwner)
+    {
+        return tokenOwner == Message.Sender || GetOwnerToOperator(tokenOwner, Message.Sender);
+    }
+
+    /// <summary>
+    /// Guarantees that the msg.sender is allowed to transfer NFT.
+    /// </summary>
+    /// <param name="tokenId">ID of the NFT to transfer.</param>
+    private void CanTransfer(Address tokenOwner, UInt256 tokenId)
+    {
+        Assert(IsOwnerOrOperator(tokenOwner) || GetIdToApproval(tokenId) == Message.Sender, "Caller is not owner nor approved for token.");
+    }
+
+    /// <summary>
+    /// Only owner can set new owner and new owner will be in pending state 
+    /// till new owner will call <see cref="ClaimOwnership"></see> method. 
+    /// </summary>
+    /// <param name="newOwner">The new owner which is going to be in pending state</param>
+    public void SetPendingOwner(Address newOwner)
+    {
+        EnsureOwnerOnly();
+        PendingOwner = newOwner;
+
+        Log(new OwnershipTransferRequestedLog { CurrentOwner = Owner, PendingOwner = newOwner });
+    }
+
+    /// <summary>
+    /// Waiting be called after new owner is requested by <see cref="SetPendingOwner"/> call.
+    /// Pending owner will be new owner after successfull call. 
+    /// </summary>
+    public void ClaimOwnership()
+    {
+        var newOwner = PendingOwner;
+
+        Assert(newOwner == Message.Sender, "ClaimOwnership must be called by the new(pending) owner.");
+
+        var oldOwner = Owner;
+        Owner = newOwner;
+        PendingOwner = Address.Zero;
+
+        Log(new OwnershipTransferedLog { PreviousOwner = oldOwner, NewOwner = newOwner });
+    }
+
+    private void EnsureOwnerOnly()
+    {
+        Assert(Message.Sender == Owner, "The method is owner only.");
+    }
+
+    /// <summary>
+    /// Mints new tokens
+    /// </summary>
+    /// <param name="to">The address that will own the minted NFT</param>
+    /// <param name="tokenId">The id of token</param>
+    /// <param name="uri">Metadata URI of the token</param>
+    public UInt256 Mint(Address to, UInt256 tokenId, string uri)
+    {
+        MintToken(to, tokenId, uri);
+
+        return tokenId;
+    }
+
+    /// <summary>
+    /// Mints new tokens
+    /// </summary>
+    /// <param name="to">The address that will own the minted NFT</param>
+    /// <param name="tokenId">The id of token</param>
+    /// <param name="uri">Metadata URI of the token</param>
+    /// <param name="data">The data param will passed destination contract</param>
+    public UInt256 SafeMint(Address to, UInt256 tokenId, string uri, byte[] data)
+    {
+        MintToken(to, tokenId, uri);
+
+        EnsureContractReceivedToken(Address.Zero, to, tokenId, data);
+
+        return tokenId;
+    }
+
+    private void MintToken(Address to, UInt256 tokenId, string uri)
+    {
+        if (OwnerOnlyMinting)
+        {
+            EnsureOwnerOnly();
+        }
+
+        var owner = GetIdToOwner(tokenId);
+
+        Assert(owner == Address.Zero, "Token already minted.");
+
+        EnsureAddressIsNotEmpty(to);
+
+        AddToken(to, tokenId);
+
+        SetIdToTokenURI(tokenId, uri);
+
+        LogTransfer(Address.Zero, to, tokenId);
+    }
+
+    /// <summary>
+    /// Notify contract for received token if destination(to) address is a contract.
+    /// Raise exception if notification fails. 
+    /// </summary>
+    /// <param name="from">The address which previously owned the token.</param>
+    /// <param name="to">Destination address that will receive the token</param>
+    /// <param name="tokenId">The token identifier which is being transferred.</param>
+    /// <param name="data">Additional data with no specified format.</param>
+    private void EnsureContractReceivedToken(Address from, Address to, UInt256 tokenId, byte[] data)
+    {
+        if (State.IsContract(to))
+        {
+            var result = Call(to, 0, "OnNonFungibleTokenReceived", new object[] { Message.Sender, from, tokenId, data }, 0);
+            Assert((bool)result.ReturnValue, "OnNonFungibleTokenReceived call failed.");
+        }
+    }
+
+    public void Burn(UInt256 tokenId)
+    {
+        Address tokenOwner = GetIdToOwner(tokenId);
+
+        Assert(tokenOwner == Message.Sender, "Only token owner can burn the token.");
+
+        ClearApproval(tokenId);
+        RemoveToken(tokenOwner, tokenId);
+
+        SetIdToTokenURI(tokenId, null);
+
+        LogTransfer(tokenOwner, Address.Zero, tokenId);
+    }
+
+    public void BurnWithMetadata(UInt256 tokenId, string metadata)
+    {
+        Burn(tokenId);
+
+        Log(new BurnMetadata() { From = Message.Sender, Amount = tokenId, Metadata = metadata });
+    }
+
+    public string TokenURI(UInt256 tokenId) => GetIdToTokenURI(tokenId);
+
+    private void EnsureAddressIsNotEmpty(Address address)
+    {
+        Assert(address != Address.Zero, "The address can not be zero.");
+    }
+
+    private enum TokenInterface
+    {
+        ISupportsInterface = 1,
+        INonFungibleToken = 2,
+        INonFungibleTokenReceiver = 3,
+        INonFungibleTokenMetadata = 4,
+        INonFungibleTokenEnumerable = 5,
+    }
+
+    public struct TransferLog
+    {
+        [Index]
+        public Address From;
+        [Index]
+        public Address To;
+        [Index]
+        public UInt256 TokenId;
+    }
+
+    public struct ApprovalLog
+    {
+        [Index]
+        public Address Owner;
+        [Index]
+        public Address Approved;
+        [Index]
+        public UInt256 TokenId;
+    }
+
+    public struct ApprovalForAllLog
+    {
+        [Index]
+        public Address Owner;
+        [Index]
+        public Address Operator;
+
+        public bool Approved;
+    }
+
+    public struct OwnershipTransferedLog
+    {
+        [Index]
+        public Address PreviousOwner;
+
+        [Index]
+        public Address NewOwner;
+    }
+
+    public struct OwnershipTransferRequestedLog
+    {
+        [Index]
+        public Address CurrentOwner;
+        [Index]
+        public Address PendingOwner;
+    }
+
+    public struct BurnMetadata
+    {
+        [Index] public Address From;
+
+        [Index] public string Metadata;
+
+        /// <summary>
+        /// The token ID of the particular NFT being burnt.
+        /// </summary>
+        [Index] public UInt256 Amount;
+    }
+}

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/InterFluxNonFungibleTokenContract.csproj
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleToken/InterFluxNonFungibleTokenContract.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Stratis.SmartContracts" Version="2.0.0" />
+    <PackageReference Include="Stratis.SmartContracts.Standards" Version="1.0.0" />
+  </ItemGroup>
+  
+</Project>

--- a/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleTokenContract.sln
+++ b/Testnet/InterFluxNonFungibleToken/InterFluxNonFungibleTokenContract.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29201.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterFluxNonFungibleTokenContract", "InterFluxNonFungibleToken\InterFluxNonFungibleTokenContract.csproj", "{D64B8959-5CC0-43D4-99B7-E07481222B5D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InterFluxNonFungibleTokenContract.Tests", "InterFluxNonFungibleToken.Tests\InterFluxNonFungibleTokenContract.Tests.csproj", "{855863D4-4F60-47D0-AD2A-164749950614}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D64B8959-5CC0-43D4-99B7-E07481222B5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D64B8959-5CC0-43D4-99B7-E07481222B5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D64B8959-5CC0-43D4-99B7-E07481222B5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D64B8959-5CC0-43D4-99B7-E07481222B5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{855863D4-4F60-47D0-AD2A-164749950614}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{855863D4-4F60-47D0-AD2A-164749950614}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{855863D4-4F60-47D0-AD2A-164749950614}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{855863D4-4F60-47D0-AD2A-164749950614}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {70BE9CE1-C24C-48EC-861C-D3FDEA2628FD}
+	EndGlobalSection
+EndGlobal

--- a/Testnet/InterFluxNonFungibleToken/README.MD
+++ b/Testnet/InterFluxNonFungibleToken/README.MD
@@ -1,0 +1,15 @@
+﻿# InterFlux Non-Fungible Token Contract
+
+**Compiler Version**
+```
+v2.0.0
+```
+**Contract Hash**
+```
+
+```
+
+**Contract Byte Code**
+```
+
+```


### PR DESCRIPTION
Incorporates various elements from the `InterFluxStandardToken` needed for SRC721-ERC721 transfers:

a. record of originating chain and contract
b. burn with metadata

(the NonFungibleToken contract already supports ownership, so that did not need to be ported)